### PR TITLE
msm8916-common: Add ro.opengles.version

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -35,6 +35,7 @@ debug.sf.hw=0
 dev.pm.dyn_samplingrate=1
 persist.demo.hdmirotationlock=false
 persist.hwc.mdpcomp.enable=true
+ro.opengles.version=196608
 
 # DRM
 drm.service.enabled=true


### PR DESCRIPTION
Define opengles version in system.prop for OpenGL ES 3.0.

Should fix incompatible apps thingy in play store. Let me know later..  Also you can switch to OpenGL ES 3.1 in a separate commit
